### PR TITLE
Fixes issue on single page checkout

### DIFF
--- a/src/Resources/public/js/app/components/braintree-method-component.js
+++ b/src/Resources/public/js/app/components/braintree-method-component.js
@@ -141,7 +141,11 @@ define(function (require) {
         },
 
         dispose: function () {
-            mediator.off('checkout:payment:before-form-serialization');
+            if (this.disposed) {
+                return;
+            }
+
+            mediator.off('checkout:payment:before-transit', this.beforeTransit, this);
 
             if (this.instance) {
                 this.instance.teardown(function (data) {
@@ -150,6 +154,8 @@ define(function (require) {
                     }
                 });
             }
+
+            BraintreeComponent.__super__.dispose.call(this);
         }
     });
 


### PR DESCRIPTION
Fix issue with event being called on old drop-in instance by correctly removing the event listener and calling the super dispose method