### PR TITLE
Feature/enable premium fraud protection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "psr-4": { "Aligent\\BraintreeBundle\\": "./src/" }
     },
     "require": {
-        "braintree/braintree_php": "3.36.*",
-        "php": ">=7.1",
+        "braintree/braintree_php": "6.4.*",
+        "php": ">=7.3",
         "oro/commerce": "3.*"
     }
 }

--- a/src/Entity/BraintreeIntegrationSettings.php
+++ b/src/Entity/BraintreeIntegrationSettings.php
@@ -112,6 +112,12 @@ class BraintreeIntegrationSettings extends Transport
     protected $settings;
 
     /**
+     * Column name shortened to braintree_fraud_advanced due to max db name length 30
+     * @var boolean @ORM\Column(name="braintree_fraud_advanced", type="boolean", options={"default"=false})
+     */
+    protected $fraudProtectionAdvanced = false;
+
+    /**
      * BraintreeIntegrationSettings constructor.
      */
     public function __construct()
@@ -334,6 +340,24 @@ class BraintreeIntegrationSettings extends Transport
     }
 
     /**
+     * @return bool
+     */
+    public function isFraudProtectionAdvanced()
+    {
+        return $this->fraudProtectionAdvanced;
+    }
+
+    /**
+     * @param bool $fraudProtectionAdvanced
+     */
+    public function setFraudProtectionAdvanced(bool $fraudProtectionAdvanced)
+    {
+        $this->fraudProtectionAdvanced = $fraudProtectionAdvanced;
+    }
+
+
+
+    /**
      * @return ParameterBag
      */
     public function getSettingsBag()
@@ -346,7 +370,8 @@ class BraintreeIntegrationSettings extends Transport
                     BraintreeConfig::ENVIRONMENT_KEY => $this->getEnvironment(),
                     BraintreeConfig::MERCHANT_ACCOUNT_ID_KEY => $this->getMerchantAccountId(),
                     BraintreeConfig::MERCHANT_ID_KEY => $this->getMerchantId(),
-                    BraintreeConfig::VAULT_KEY => $this->isVaultModeActive()
+                    BraintreeConfig::VAULT_KEY => $this->isVaultModeActive(),
+                    BraintreeConfig::FRAUD_PROTECTION_ADVANCED_KEY => $this->isFraudProtectionAdvanced()
                 ]
             );
         }

--- a/src/EventListener/AdvancedFraudEventListener.php
+++ b/src/EventListener/AdvancedFraudEventListener.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @category  Aligent
+ * @package   BraintreeBundle
+ * @author    Jan Plank <jan.plank@aligent.com.au>
+ * @copyright 2021 Aligent Consulting.
+ * @license
+ * @link      http://www.aligent.com.au/
+ */
+
+namespace Aligent\BraintreeBundle\EventListener;
+
+use Aligent\BraintreeBundle\Event\BraintreePaymentActionEvent;
+use Oro\Bundle\PaymentBundle\Entity\PaymentTransaction;
+
+class AdvancedFraudEventListener
+{
+
+    /**
+     * Add deviceData to payload as required for abraintree advanced fraud detection
+     * https://developer.paypal.com/braintree/docs/guides/premium-fraud-management-tools/server-side
+     * @param BraintreePaymentActionEvent $actionEvent
+     */
+    public function onPurchase(BraintreePaymentActionEvent $actionEvent)
+    {
+        if ($actionEvent->getConfig()->isFraudProtectionAdvancedEnabled()) {
+            $data = $actionEvent->getData();
+
+            $paymentTransaction = $actionEvent->getPaymentTransaction();
+            $data['deviceData'] = $this->getDeviceData($paymentTransaction);
+
+            $actionEvent->setData($data);
+        }
+    }
+
+    /**
+     * Extracts the device data out of the additional data array
+     * @param PaymentTransaction $paymentTransaction
+     * @return string
+     */
+    protected function getDeviceData(PaymentTransaction $paymentTransaction)
+    {
+        $transactionOptions = $paymentTransaction->getTransactionOptions();
+
+        if (!isset($transactionOptions['additionalData'])) {
+            throw new InvalidArgumentException('Payment Transaction does not contain additionalData');
+        }
+
+        $additionalData = json_decode($transactionOptions['additionalData'], true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new InvalidArgumentException(
+                "Error decoding Payment Transaction additional data Error: " . json_last_error_msg()
+            );
+        }
+
+        if (!isset($additionalData['deviceData'])) {
+            throw new InvalidArgumentException('Payment Transaction additionalData does not contain a deviceData');
+        }
+
+        return $additionalData['deviceData'];
+    }
+
+}

--- a/src/Form/Type/BraintreeIntegrationSettingsType.php
+++ b/src/Form/Type/BraintreeIntegrationSettingsType.php
@@ -135,6 +135,13 @@ class BraintreeIntegrationSettingsType extends AbstractType
                 ]
             )
             ->add(
+                'fraudProtectionAdvanced',
+                CheckboxType::class,
+                [
+                    'label' => 'aligent.braintree.settings.fraud_protection_advanced.label'
+                ]
+            )
+            ->add(
                 'paymentMethodSettings',
                 PaymentMethodSettingsType::class,
                 [

--- a/src/Method/Config/BraintreeConfig.php
+++ b/src/Method/Config/BraintreeConfig.php
@@ -164,7 +164,7 @@ class BraintreeConfig extends AbstractParameterBagPaymentConfig implements Brain
     /**
      * @return bool
      */
-    public function isFraudProtectionAdvanced()
+    public function isFraudProtectionAdvancedEnabled()
     {
         return (boolean) $this->get(self::FRAUD_PROTECTION_ADVANCED_KEY);
     }

--- a/src/Method/Config/BraintreeConfig.php
+++ b/src/Method/Config/BraintreeConfig.php
@@ -160,4 +160,12 @@ class BraintreeConfig extends AbstractParameterBagPaymentConfig implements Brain
         $this->set(self::PAYMENT_METHODS_CONFIG_KEY, $settings);
         return $this;
     }
+
+    /**
+     * @return bool
+     */
+    public function isFraudProtectionAdvanced()
+    {
+        return (boolean) $this->get(self::FRAUD_PROTECTION_ADVANCED_KEY);
+    }
 }

--- a/src/Method/Config/BraintreeConfigInterface.php
+++ b/src/Method/Config/BraintreeConfigInterface.php
@@ -127,5 +127,5 @@ interface BraintreeConfigInterface extends PaymentConfigInterface
     /**
      * @return bool
      */
-    public function isFraudProtectionAdvanced();
+    public function isFraudProtectionAdvancedEnabled();
 }

--- a/src/Method/Config/BraintreeConfigInterface.php
+++ b/src/Method/Config/BraintreeConfigInterface.php
@@ -28,6 +28,7 @@ interface BraintreeConfigInterface extends PaymentConfigInterface
     const SHORT_LABELS_KEY = 'short_labels';
     const LABEL_KEY = 'label';
     const SHORT_LABEL_KEY = 'short_label';
+    const FRAUD_PROTECTION_ADVANCED_KEY = 'fraud_protection_advanced';
 
     const PAYPAL_FLOW_VAULT = 'vault';
     const PAYPAL_FLOW_CHECKOUT = 'checkout';
@@ -122,4 +123,9 @@ interface BraintreeConfigInterface extends PaymentConfigInterface
      * @param array $settings
      */
     public function setPaymentMethodSettings(array $settings);
+
+    /**
+     * @return bool
+     */
+    public function isFraudProtectionAdvanced();
 }

--- a/src/Method/View/BraintreeView.php
+++ b/src/Method/View/BraintreeView.php
@@ -66,6 +66,7 @@ class BraintreeView implements PaymentMethodViewInterface
     }
 
     /**
+     * These keys are used in the javascript file 'braintree-method-component.js to retrieve data from backend
      * @param PaymentContextInterface $context
      * @return array
      */
@@ -75,7 +76,7 @@ class BraintreeView implements PaymentMethodViewInterface
             'authToken' => $this->getAuthToken(),
             'paymentMethodSettings' => $this->getPaymentMethodSettings($context),
             'vaultMode' => $this->config->isVaultMode(),
-            'fraudProtectionAdvanced' => $this->config->isFraudProtectionAdvanced(),
+            'fraudProtectionAdvanced' => $this->config->isFraudProtectionAdvancedEnabled(),
         ];
     }
 

--- a/src/Method/View/BraintreeView.php
+++ b/src/Method/View/BraintreeView.php
@@ -74,7 +74,8 @@ class BraintreeView implements PaymentMethodViewInterface
         return [
             'authToken' => $this->getAuthToken(),
             'paymentMethodSettings' => $this->getPaymentMethodSettings($context),
-            'vaultMode' => $this->config->isVaultMode()
+            'vaultMode' => $this->config->isVaultMode(),
+            'fraudProtectionAdvanced' => $this->config->isFraudProtectionAdvanced(),
         ];
     }
 

--- a/src/Migrations/Schema/v1_1/AddEnablePremiumFraudProtectionField.php
+++ b/src/Migrations/Schema/v1_1/AddEnablePremiumFraudProtectionField.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @category  Aligent
+ * @package   BraintreeBundle
+ * @author    Jan Plank <jan.plank@aligent.com.au>
+ * @copyright 2021 Aligent Consulting.
+ * @license
+ * @link      http://www.aligent.com.au/
+ */
+
+namespace Aligent\BraintreeBundle\Migrations\Schema\v1_1;
+
+use Doctrine\DBAL\Schema\Schema;
+use Oro\Bundle\MigrationBundle\Migration\Migration;
+use Oro\Bundle\MigrationBundle\Migration\QueryBag;
+
+class AddEnablePremiumFraudProtectionField implements Migration
+{
+    /**
+     * @inheritDoc
+     */
+    public function up(Schema $schema, QueryBag $queries)
+    {
+        $table = $schema->getTable('oro_integration_transport');
+        if (!$table->hasColumn('braintree_fraud_advanced')) {
+            $table->addColumn('braintree_fraud_advanced', 'boolean', ['default' => '0', 'notnull' => false]);
+        }
+    }
+}

--- a/src/Resources/config/event_listeners.yml
+++ b/src/Resources/config/event_listeners.yml
@@ -3,3 +3,8 @@ services:
     class: Aligent\BraintreeBundle\EventListener\PurchaseActionEventListener
     tags:
       - { name: kernel.event_listener, event: aligent_braintree.payment_action.purchase, method: onPurchase }
+
+  Aligent\BraintreeBundle\EventListener\AdvancedFraudEventListener:
+    class: Aligent\BraintreeBundle\EventListener\AdvancedFraudEventListener
+    tags:
+      - { name: kernel.event_listener, event: aligent_braintree.payment_action.purchase, method: onPurchase }

--- a/src/Resources/public/js/app/components/braintree-method-component.js
+++ b/src/Resources/public/js/app/components/braintree-method-component.js
@@ -6,6 +6,10 @@ define(function (require) {
     var __ = require('orotranslation/js/translator');
     var mediator = require('oroui/js/mediator');
     var BaseComponent = require('oroui/js/app/components/base/component');
+
+    //WORKAROUND: Preferred way to require braintree data collector here, but didn't work. As workaround added to:
+    //src/Resources/views/layouts/default/imports/oro_payment_method_options/layout.html.twig
+    //require('aligentbraintree/js/braintree/braintree-data-collector'); //data collector needed for drop in ui with advanced fraud
     var dropin = require('aligentbraintree/js/braintree/braintree-drop-in-ui');
 
     BraintreeComponent = BaseComponent.extend({

--- a/src/Resources/public/js/app/components/braintree-method-component.js
+++ b/src/Resources/public/js/app/components/braintree-method-component.js
@@ -17,7 +17,8 @@ define(function (require) {
             authToken: null,
             vaultMode: false,
             selectors: {
-                nonceInputSelector: '#nonce-input'
+                nonceInputSelector: '#nonce-input',
+                deviceDataInputSelector: '#device-data-input'
             },
             paymentMethodSettings: {}
         },
@@ -32,18 +33,27 @@ define(function (require) {
          */
         nonceInput: null,
 
+        /**
+         * @property {Object}
+         */
+        deviceDataInput: null,
+
         initialize: function (options) {
             this.options = _.extend({}, this.options, options);
             this.$el = this.options._sourceElement;
             this.nonceInput = $(this.options.selectors.nonceInputSelector);
+            this.deviceDataInput = $(this.options.selectors.deviceDataInputSelector);
             var component = this;
 
             mediator.on('checkout:payment:before-transit', this.beforeTransit, this);
 
+            //Options keys from the backend can be seen in \Aligent\BraintreeBundle\Method\View\BraintreeView.php
+            //options are passed through from twig widget: _payment_methods_aligent_braintree_widget
             var dropinOptions = {
                 authorization:  this.options.authToken,
                 selector: this.$el[0],
-                vaultManager: this.options.vaultMode
+                vaultManager: this.options.vaultMode,
+                dataCollector: this.options.fraudProtectionAdvanced
             };
 
             dropinOptions = _.extend(dropinOptions, this.options.paymentMethodSettings);
@@ -66,7 +76,7 @@ define(function (require) {
                     // if we have a saved payment method we can request a nonce for
                     // fetch and save it now to the hidden input field
                     if (component.instance.isPaymentMethodRequestable()) {
-                        component.instance.requestPaymentMethod(component.storeNonce.bind(component));
+                        component.instance.requestPaymentMethod(component.storeAdditionalData.bind(component));
                     }
                 }
             );
@@ -83,7 +93,13 @@ define(function (require) {
 
                 // if we already have the nonce set as additional data and continue
                 if (this.nonceInput.val()) {
-                    mediator.trigger('checkout:payment:additional-data:set', JSON.stringify({nonce: this.nonceInput.val()}));
+                    var additionalData = {nonce: this.nonceInput.val()};
+
+                    if (this.deviceDataInput.val()) {
+                        additionalData.deviceData = this.deviceDataInput.val();
+                    }
+
+                    mediator.trigger('checkout:payment:additional-data:set', JSON.stringify(additionalData));
                     event.resume();
                 } else {
                     // Else request the nonce, set the additional data and then continue the event
@@ -97,7 +113,13 @@ define(function (require) {
                                 return;
                             }
 
-                            mediator.trigger('checkout:payment:additional-data:set', JSON.stringify({nonce: payload.nonce}));
+                            var additionalData = {nonce: payload.nonce};
+
+                            if (payload.deviceData) {
+                                additionalData.deviceData = payload.deviceData;
+                            }
+
+                            mediator.trigger('checkout:payment:additional-data:set', JSON.stringify(additionalData));
                             event.resume();
                         }
                     );
@@ -112,7 +134,7 @@ define(function (require) {
          */
         onPaymentMethodRequestable: function(event) {
             if (event.paymentMethodIsSelected) {
-                this.instance.requestPaymentMethod(this.storeNonce.bind(this));
+                this.instance.requestPaymentMethod(this.storeAdditionalData.bind(this));
             }
         },
 
@@ -129,7 +151,7 @@ define(function (require) {
          * @param err
          * @param payload
          */
-        storeNonce: function(err, payload) {
+        storeAdditionalData: function(err, payload) {
             if (err) {
                 console.error(err);
                 this.instance.clearSelectedPaymentMethod();
@@ -138,6 +160,10 @@ define(function (require) {
             }
 
             this.nonceInput.val(payload.nonce);
+
+            if (payload.deviceData) {
+                this.deviceDataInput.val(payload.deviceData);
+            }
         },
 
         dispose: function () {

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -28,6 +28,8 @@ aligent:
         label: "Private Key"
       vault_mode:
         label: "Vault Mode"
+      fraud_protection_advanced:
+        label: "Enable Fraud Protection Advanced"
       payment_method_settings:
         label: "Payment Method Settings"
       credit_card:

--- a/src/Resources/views/layouts/blank/config/requirejs.yml
+++ b/src/Resources/views/layouts/blank/config/requirejs.yml
@@ -3,3 +3,4 @@ config:
         'aligentbraintree/js/app/components/braintree-method-component': 'bundles/aligentbraintree/js/app/components/braintree-method-component.js'
         'aligentbraintree/js/app/components/order-review-component': 'bundles/aligentbraintree/js/app/components/order-review-component.js'
         'aligentbraintree/js/braintree/braintree-drop-in-ui': 'https://js.braintreegateway.com/web/dropin/1.31.2/js/dropin.min.js'
+        'aligentbraintree/js/braintree/braintree-data-collector': 'https://js.braintreegateway.com/web/3.80.0/js/data-collector.min.js'

--- a/src/Resources/views/layouts/blank/config/requirejs.yml
+++ b/src/Resources/views/layouts/blank/config/requirejs.yml
@@ -2,4 +2,4 @@ config:
     paths:
         'aligentbraintree/js/app/components/braintree-method-component': 'bundles/aligentbraintree/js/app/components/braintree-method-component.js'
         'aligentbraintree/js/app/components/order-review-component': 'bundles/aligentbraintree/js/app/components/order-review-component.js'
-        'aligentbraintree/js/braintree/braintree-drop-in-ui': 'https://js.braintreegateway.com/web/dropin/1.21.0/js/dropin.min.js'
+        'aligentbraintree/js/braintree/braintree-drop-in-ui': 'https://js.braintreegateway.com/web/dropin/1.31.2/js/dropin.min.js'

--- a/src/Resources/views/layouts/default/imports/oro_payment_method_options/layout.html.twig
+++ b/src/Resources/views/layouts/default/imports/oro_payment_method_options/layout.html.twig
@@ -1,5 +1,7 @@
 {% block _payment_methods_aligent_braintree_widget %}
     {% set paymentMethodComponentOptions = view.options|default({})|merge({paymentMethod: name}) %}
+    <script src="https://js.braintreegateway.com/web/3.80.0/js/data-collector.min.js"></script>
+
     <div
         data-page-component-module="aligentbraintree/js/app/components/braintree-method-component"
         data-page-component-options="{{ paymentMethodComponentOptions|json_encode }}"


### PR DESCRIPTION
Add Braintree Fraud Protection Advanced feature.

* A new configuration field was added to the braintree orocommerce  integration admin ui to enable/disable this functionality
* To use this feature it will need to be enabled in braintree Settings->Fraud Management->Fraud Protection Advanced->Enable

Oro Enable settings:
![cp-fraud-protection-flag](https://user-images.githubusercontent.com/5624661/130540934-98e68768-4681-4cb2-a664-8f1cae916d70.png)

Braintree settings:
![cp-fraud-protection-flag-braintree](https://user-images.githubusercontent.com/5624661/130548482-aff2afbb-6126-4510-adf9-087af7daf1a1.png)

Confirmation fraud protection is enabled in braintree:
![cp-premium-fraud-captured](https://user-images.githubusercontent.com/5624661/130540999-9abf6c13-8fb6-4d79-909e-05d41c4b1f0d.png)
