### PR TITLE
Add OroCommerce 5.0 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ Braintree Payment Gateway Bundle
 
 Facts
 -----
-- version: 4.2.0
 - composer name: aligent/braintree-orocommerce
 
 Description

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         "psr-4": { "Aligent\\BraintreeBundle\\": "./src/" }
     },
     "require": {
-        "braintree/braintree_php": "6.4.*",
-        "php": "~7.4.14 || ~8.0.0",
-        "oro/commerce": "4.2.*"
+        "braintree/braintree_php": "6.8.*",
+        "php": "~8.1.0",
+        "oro/commerce": "5.0.*"
     },
     "extra": {
         "npm": {
-            "braintree-web-drop-in": "1.32.1"
+            "braintree-web-drop-in": "1.33.2"
         }
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,11 +23,10 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root(AligentBraintreeExtension::ALIAS);
+        $treeBuilder = new TreeBuilder(AligentBraintreeExtension::ALIAS);
 
         SettingsBuilder::append(
-            $rootNode,
+            $treeBuilder->getRootNode(),
             [
                 'experimental_payment_methods' => ['type' => 'boolean', 'value' => false]
             ]


### PR DESCRIPTION
* Update Composer requirements from 4.2.X to 5.0.X and PHP 8.1
* Remove version number from README
* Bump Braintree dependencies to latest stable versions

NOTE: There may be additional fixes required once this has been tested in OroCommerce 5.0.X

## Braintree Dependency Changelogs
https://github.com/braintree/braintree-web-drop-in/blob/main/CHANGELOG.md
https://github.com/braintree/braintree_php/blob/master/CHANGELOG.md