### PR TITLE
Upgrade Braintree SDK to 6.23.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "psr-4": { "Aligent\\BraintreeBundle\\": "./src/" }
     },
     "require": {
-        "braintree/braintree_php": "6.4.*",
+        "braintree/braintree_php": "6.23.*",
         "php": "~7.4.14 || ~8.0.0",
         "oro/commerce": "4.2.*"
     },


### PR DESCRIPTION
Upgrade to the latest Braintree SDK available [6.24.0](https://github.com/braintree/braintree_php/releases/tag/6.24.0)

[Changes](https://github.com/braintree/braintree_php/compare/6.4.0...6.24.0)