### PR TITLE
Upgrade Braintree SDK to 6.26.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "braintree/braintree_php": "6.8.*",
+        "braintree/braintree_php": "6.26.*",
         "php": "~8.1.0",
         "oro/commerce": "5.0.*"
     },


### PR DESCRIPTION
Upgrade to the latest Braintree SDK available [6.26.0](https://github.com/braintree/braintree_php/releases/tag/6.26.0)

[Changes](https://github.com/braintree/braintree_php/compare/6.8.0...6.26.0)